### PR TITLE
Fix float type of matrix size in Python 3

### DIFF
--- a/avatargen.py
+++ b/avatargen.py
@@ -14,7 +14,7 @@ def generate(size, block_size, block_count, color=None, block_color=None):
 
     # Create a matrix which gives us the "plan" of where to plot
     # the blocks on the image.
-    matrix_size = (size / block_size) - 1
+    matrix_size = int(size / block_size) - 1
     matrix = _create_matrix(matrix_size, block_count)
 
     # Create canvas.


### PR DESCRIPTION
In Python 3 division operator "/" produces "float" type output.
Use either conversion to 'int' type or '//' operator to get correct matrix size 